### PR TITLE
Mask secrets read from .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ It reads the `.env` file from the root of this repo and provides environment var
 
 Override the path to the `.env` file. Default is `.env` in the repository root.
 
+### `log-variables`
+
+Log variables after reading from the `.env` file.
+
+### `mask-variables`
+
+Mask values after reading from the `.env` file.
+
 ## Outputs
 
 ### `generic`

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'whether to log the variables to output or not'
     required: false
     default: 'false'
+  mask-variables:
+    description: 'whether to mask the variables as secrets or not'
+    required: false
+    default: 'false'
 outputs:
   generic: # output will be available to future steps 
     description: 'This command will have generic output variables based on .env'

--- a/index.js
+++ b/index.js
@@ -1,23 +1,33 @@
 const core = require('@actions/core');
 const dotenvAction = require('./dotenv_action');
 try {
-  const dotenvFile = core.getInput("path");
-  const logVariables = core.getInput("log-variables").toLowerCase() === "true";
+  const dotenvFile = core.getInput('path');
+  const logVariables = core.getInput('log-variables').toLowerCase() === 'true';
+  const maskVariables =
+    core.getInput('mask-variables').toLowerCase() === 'true';
   const variables = dotenvAction(dotenvFile, logVariables);
+
+  if (maskVariables) {
+    for (const key in variables) {
+      const value = variables[key];
+      core.setSecret(value);
+    }
+  }
 
   if (logVariables) {
     console.log(variables);
   } else {
-    console.log(`loaded ${Object.keys(variables).length} values into the environment`);
+    console.log(
+      `loaded ${Object.keys(variables).length} values into the environment`
+    );
   }
 
-  core.setOutput("generic", "please check for actual outputs");
-  
+  core.setOutput('generic', 'please check for actual outputs');
+
   for (const key in variables) {
     const value = variables[key];
     core.setOutput(key, value);
   }
-  
 } catch (error) {
   core.setFailed(error.message);
 }


### PR DESCRIPTION
Hi, i would like to introduce the `mask-variables` option to optionally mask all secrets read from .env file.